### PR TITLE
Update st.query_params usage

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -414,7 +414,7 @@ st.warning('''
            * Be aware that the new URL format might change in the near future again (hopefully to something more clear and permanent).
            ''')
 
-streamlit_analytics.start_tracking()
+# streamlit_analytics.start_tracking()
 
 
 # footer
@@ -466,11 +466,11 @@ hide_streamlit_style = """
             """
 st.markdown(hide_streamlit_style, unsafe_allow_html=True)
 
-if os.path.exists('.streamlit/secrets.toml'):
-    streamlit_analytics.stop_tracking(unsafe_password=st.secrets["streamlit_analytics_password"])
-else:
-    # Use default password if it is not defined in a streamlit secret. Change this if you want to use it!
-    streamlit_analytics.stop_tracking(unsafe_password='opdskf03i45+0ikfg')
+# if os.path.exists('.streamlit/secrets.toml'):
+#     streamlit_analytics.stop_tracking(unsafe_password=st.secrets["streamlit_analytics_password"])
+# else:
+#     # Use default password if it is not defined in a streamlit secret. Change this if you want to use it!
+#     streamlit_analytics.stop_tracking(unsafe_password='opdskf03i45+0ikfg')
 
 # if not in analytics mode, clear params from URL because Streamlit 1.0 still
 # get some hickups when one changes the params; it then gets confused with the

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -84,9 +84,6 @@ def clear_url():
     version 1.0. Will hopefully be fixed in the future. Then hopefully all
     occurences of "clear_url" can be removed.
     """
-    # set_query_params2 = {}
-    # set_query_params2["embedded"] = 'true'
-    # st.query_params(**set_query_params2)
     st.query_params.clear()
     st.query_params["embedded"] = 'true'
 
@@ -285,10 +282,7 @@ with st.sidebar.container():
     # st.session_state["bodies"] = body_list
     st.session_state["speeds"] = vsw_list
 
-# url = 'http://localhost:8501/?'
-# url = 'https://share.streamlit.io/jgieseler/solar-mach?'
-# url = 'https://jgieseler-solar-mach-streamlit-app-aj6zer.streamlitapp.com/?embedded=true&'
-url = 'https://solar-mach-query.streamlit.app/?embedded=true&'
+url = 'https://solar-mach.streamlit.app/?embedded=true&'
 
 # Get all the parameters from st.session_state and store them in set_query_params so you can build the url
 for p in ["date", "time", "coord_sys", "plot_spirals", "plot_sun_body_line", "plot_trans", "plot_markers",

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from stqdm import stqdm
 import streamlit as st
-# import streamlit_analytics  # TODO: un-comment when streamlit-analytics has been updated with https://github.com/jrieke/streamlit-analytics/pull/44
+import streamlit_analytics  # TODO: un-comment when streamlit-analytics has been updated with https://github.com/jrieke/streamlit-analytics/pull/44
 from astropy.coordinates import SkyCoord
 from sunpy.coordinates import frames
 from solarmach import SolarMACH, print_body_list, get_sw_speed
@@ -413,7 +413,7 @@ st.warning('''
            * Be aware that the new URL format might change in the near future again (hopefully to something more clear and permanent).
            ''')
 
-# streamlit_analytics.start_tracking()  # TODO: un-comment when streamlit-analytics has been updated with https://github.com/jrieke/streamlit-analytics/pull/44
+streamlit_analytics.start_tracking()  # TODO: un-comment when streamlit-analytics has been updated with https://github.com/jrieke/streamlit-analytics/pull/44
 
 
 # footer
@@ -466,11 +466,11 @@ hide_streamlit_style = """
 st.markdown(hide_streamlit_style, unsafe_allow_html=True)
 
 # TODO: un-comment the following when streamlit-analytics has been updated with https://github.com/jrieke/streamlit-analytics/pull/44
-# if os.path.exists('.streamlit/secrets.toml'):
-#     streamlit_analytics.stop_tracking(unsafe_password=st.secrets["streamlit_analytics_password"])
-# else:
-#     # Use default password if it is not defined in a streamlit secret. Change this if you want to use it!
-#     streamlit_analytics.stop_tracking(unsafe_password='opdskf03i45+0ikfg')
+if os.path.exists('.streamlit/secrets.toml'):
+    streamlit_analytics.stop_tracking(unsafe_password=st.secrets["streamlit_analytics_password"])
+else:
+    # Use default password if it is not defined in a streamlit secret. Change this if you want to use it!
+    streamlit_analytics.stop_tracking(unsafe_password='opdskf03i45+0ikfg')
 
 # if not in analytics mode, clear params from URL because Streamlit 1.0 still
 # get some hickups when one changes the params; it then gets confused with the

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from stqdm import stqdm
 import streamlit as st
-import streamlit_analytics
+# import streamlit_analytics  # TODO: un-comment when streamlit-analytics has been updated with https://github.com/jrieke/streamlit-analytics/pull/44
 from astropy.coordinates import SkyCoord
 from sunpy.coordinates import frames
 from solarmach import SolarMACH, print_body_list, get_sw_speed
@@ -78,15 +78,17 @@ st.success('''
 #     st.query_params(**set_query_params)
 
 
-# def clear_url():
-#     """
-#     Clear parameters from URL bc. otherwise input becomes buggy as of Streamlit
-#     version 1.0. Will hopefully be fixed in the future. Then hopefully all
-#     occurences of "clear_url" can be removed.
-#     """
-#     set_query_params2 = {}
-#     set_query_params2["embedded"] = 'true'
-#     st.query_params(**set_query_params2)
+def clear_url():
+    """
+    Clear parameters from URL bc. otherwise input becomes buggy as of Streamlit
+    version 1.0. Will hopefully be fixed in the future. Then hopefully all
+    occurences of "clear_url" can be removed.
+    """
+    # set_query_params2 = {}
+    # set_query_params2["embedded"] = 'true'
+    # st.query_params(**set_query_params2)
+    st.query_params.clear()
+    st.query_params["embedded"] = 'true'
 
 
 def obtain_vsw(body_list, date):
@@ -96,8 +98,11 @@ def obtain_vsw(body_list, date):
     st.session_state["speeds"] = vsw_list2
 
 
-# obtain query paramamters from URL
-query_params = st.query_params
+# obtain query paramamters from URL; convert query dictionary to old format
+query_params = {}
+for key in st.query_params.keys():
+    query_params[key] = st.query_params.get_all(key)
+
 
 # define empty dict for new params to put into URL (only in box at the bottom)
 set_query_params = {}
@@ -414,7 +419,7 @@ st.warning('''
            * Be aware that the new URL format might change in the near future again (hopefully to something more clear and permanent).
            ''')
 
-# streamlit_analytics.start_tracking()
+# streamlit_analytics.start_tracking()  # TODO: un-comment when streamlit-analytics has been updated with https://github.com/jrieke/streamlit-analytics/pull/44
 
 
 # footer
@@ -466,6 +471,7 @@ hide_streamlit_style = """
             """
 st.markdown(hide_streamlit_style, unsafe_allow_html=True)
 
+# TODO: un-comment the following when streamlit-analytics has been updated with https://github.com/jrieke/streamlit-analytics/pull/44
 # if os.path.exists('.streamlit/secrets.toml'):
 #     streamlit_analytics.stop_tracking(unsafe_password=st.secrets["streamlit_analytics_password"])
 # else:
@@ -475,8 +481,8 @@ st.markdown(hide_streamlit_style, unsafe_allow_html=True)
 # if not in analytics mode, clear params from URL because Streamlit 1.0 still
 # get some hickups when one changes the params; it then gets confused with the
 # params in the URL and the one from the widgets.
-# if 'analytics' in query_params.keys():
-#     if not query_params['analytics'][0] == 'on':
-#         clear_url()
-# else:
-#     clear_url()
+if 'analytics' in query_params.keys():
+    if not query_params['analytics'][0] == 'on':
+        clear_url()
+else:
+    clear_url()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -283,7 +283,7 @@ with st.sidebar.container():
 # url = 'http://localhost:8501/?'
 # url = 'https://share.streamlit.io/jgieseler/solar-mach?'
 # url = 'https://jgieseler-solar-mach-streamlit-app-aj6zer.streamlitapp.com/?embedded=true&'
-url = 'https://solar-mach.streamlit.app/?embedded=true&'
+url = 'https://solar-mach-query.streamlit.app/?embedded=true&'
 
 # Get all the parameters from st.session_state and store them in set_query_params so you can build the url
 for p in ["date", "time", "coord_sys", "plot_spirals", "plot_sun_body_line", "plot_trans", "plot_markers",

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -75,7 +75,7 @@ st.success('''
 
 # Save parameters to URL for sharing and bookmarking
 def make_url(set_query_params):
-    st.experimental_set_query_params(**set_query_params)
+    st.query_params(**set_query_params)
 
 
 def clear_url():
@@ -86,7 +86,7 @@ def clear_url():
     """
     set_query_params2 = {}
     set_query_params2["embedded"] = 'true'
-    st.experimental_set_query_params(**set_query_params2)
+    st.query_params(**set_query_params2)
 
 
 def obtain_vsw(body_list, date):
@@ -97,7 +97,7 @@ def obtain_vsw(body_list, date):
 
 
 # obtain query paramamters from URL
-query_params = st.experimental_get_query_params()
+query_params = st.query_params()
 
 # define empty dict for new params to put into URL (only in box at the bottom)
 set_query_params = {}

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -74,19 +74,19 @@ st.success('''
 
 
 # Save parameters to URL for sharing and bookmarking
-def make_url(set_query_params):
-    st.query_params(**set_query_params)
+# def make_url(set_query_params):
+#     st.query_params(**set_query_params)
 
 
-def clear_url():
-    """
-    Clear parameters from URL bc. otherwise input becomes buggy as of Streamlit
-    version 1.0. Will hopefully be fixed in the future. Then hopefully all
-    occurences of "clear_url" can be removed.
-    """
-    set_query_params2 = {}
-    set_query_params2["embedded"] = 'true'
-    st.query_params(**set_query_params2)
+# def clear_url():
+#     """
+#     Clear parameters from URL bc. otherwise input becomes buggy as of Streamlit
+#     version 1.0. Will hopefully be fixed in the future. Then hopefully all
+#     occurences of "clear_url" can be removed.
+#     """
+#     set_query_params2 = {}
+#     set_query_params2["embedded"] = 'true'
+#     st.query_params(**set_query_params2)
 
 
 def obtain_vsw(body_list, date):
@@ -97,7 +97,7 @@ def obtain_vsw(body_list, date):
 
 
 # obtain query paramamters from URL
-query_params = st.query_params()
+query_params = st.query_params
 
 # define empty dict for new params to put into URL (only in box at the bottom)
 set_query_params = {}
@@ -475,8 +475,8 @@ else:
 # if not in analytics mode, clear params from URL because Streamlit 1.0 still
 # get some hickups when one changes the params; it then gets confused with the
 # params in the URL and the one from the widgets.
-if 'analytics' in query_params.keys():
-    if not query_params['analytics'][0] == 'on':
-        clear_url()
-else:
-    clear_url()
+# if 'analytics' in query_params.keys():
+#     if not query_params['analytics'][0] == 'on':
+#         clear_url()
+# else:
+#     clear_url()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from stqdm import stqdm
 import streamlit as st
-import streamlit_analytics  # TODO: un-comment when streamlit-analytics has been updated with https://github.com/jrieke/streamlit-analytics/pull/44
+# import streamlit_analytics  # TODO: un-comment when streamlit-analytics has been updated with https://github.com/jrieke/streamlit-analytics/pull/44
 from astropy.coordinates import SkyCoord
 from sunpy.coordinates import frames
 from solarmach import SolarMACH, print_body_list, get_sw_speed
@@ -413,7 +413,7 @@ st.warning('''
            * Be aware that the new URL format might change in the near future again (hopefully to something more clear and permanent).
            ''')
 
-streamlit_analytics.start_tracking()  # TODO: un-comment when streamlit-analytics has been updated with https://github.com/jrieke/streamlit-analytics/pull/44
+# streamlit_analytics.start_tracking()  # TODO: un-comment when streamlit-analytics has been updated with https://github.com/jrieke/streamlit-analytics/pull/44
 
 
 # footer
@@ -466,11 +466,11 @@ hide_streamlit_style = """
 st.markdown(hide_streamlit_style, unsafe_allow_html=True)
 
 # TODO: un-comment the following when streamlit-analytics has been updated with https://github.com/jrieke/streamlit-analytics/pull/44
-if os.path.exists('.streamlit/secrets.toml'):
-    streamlit_analytics.stop_tracking(unsafe_password=st.secrets["streamlit_analytics_password"])
-else:
-    # Use default password if it is not defined in a streamlit secret. Change this if you want to use it!
-    streamlit_analytics.stop_tracking(unsafe_password='opdskf03i45+0ikfg')
+# if os.path.exists('.streamlit/secrets.toml'):
+#     streamlit_analytics.stop_tracking(unsafe_password=st.secrets["streamlit_analytics_password"])
+# else:
+#     # Use default password if it is not defined in a streamlit secret. Change this if you want to use it!
+#     streamlit_analytics.stop_tracking(unsafe_password='opdskf03i45+0ikfg')
 
 # if not in analytics mode, clear params from URL because Streamlit 1.0 still
 # get some hickups when one changes the params; it then gets confused with the


### PR DESCRIPTION
[st.experimental_get_query_params](https://docs.streamlit.io/library/api-reference/utilities/st.experimental_get_query_params) and [st.experimental_set_query_params](https://docs.streamlit.io/library/api-reference/utilities/st.experimental_set_query_params) were deprecated in streamlit version 1.30.0. Use [st.query_params](https://docs.streamlit.io/library/api-reference/utilities/st.query_params) instead.